### PR TITLE
Corrige cómo borrar un branch remoto

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ git push --set-upstream origin <BRANCH_NAME>
 
 ```git
 git branch -d <BRANCH_NAME> // borra el branch local
-git branch -D <BRANCH_NAME> // borra el branch de GitHub. También podemos hacerlo desde GitHub
+git push origin --delete <BRANCH_NAME> // borra el branch remoto, es decir en Github. También podemos hacerlo desde GitHub 
+git branch -D <BRANCH_NAME> // borra el branch local aunque no haya sido mergeado a master
 ```
 
 > :warning: Recuerden _pullear_ los cambios de _master_ antes de _puhsear_ y arrancar una nueva feature!


### PR DESCRIPTION
Borrando branches con `git branch -D <branch>` después de haber hecho `git branch -d <branch>` me decía que no encontraba la rama a borrar. Ahora leyendo el texto de [Atlassian](https://www.atlassian.com/git/tutorials/using-branches) entendí por qué.

Y de la documentación de git: 

> Deleting Remote Branches
> 
> Suppose you’re done with a remote branch — say you and your collaborators are finished with a feature and have merged it into your remote’s master branch (or whatever branch your stable codeline is in). You can delete a remote branch using the --delete option to git push. If you want to delete your serverfix branch from the server, you run the following:
> 
> ```
> $ git push origin --delete serverfix
> To https://github.com/schacon/simplegit
>  - [deleted]         serverfix
> 
> ```
> 